### PR TITLE
Update Ramda URL to use the offocial Ramda repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ramda"]
 	path = lib
-	url = https://github.com/CrossEye/ramda.git
+	url = https://github.com/ramda/ramda.git

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
     name: 'kevohagan:ramda',
     summary: 'A practical functional library for Javascript programmers.',
-    version: '0.1.0',
+    version: '0.1.1',
     git: 'https://github.com/kevohagan/meteor-ramda.git',
     upstreamVersion: "0.1.0"
 });


### PR DESCRIPTION
- Version bump

The pervious Ramda repo seems to have git history rewritten, and the previous commit the `lib` submodule points to no longer exists.
